### PR TITLE
update return type for jsonSerialize

### DIFF
--- a/Photo.php
+++ b/Photo.php
@@ -71,7 +71,7 @@ namespace IdnoPlugins\Photo {
         /**
          * Extend json serialisable to include some extra data
          */
-        public function jsonSerialize()
+        public function jsonSerialize():mixed
         {
             $object = parent::jsonSerialize();
 


### PR DESCRIPTION
In recent PHP versions the mismatched jsonSerialize definition fails because it does not match the version in Idno/Common/Entity.php